### PR TITLE
Adjustments for Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 import os
 import re
 import sys
+import platform
 import glob
 import subprocess
 
@@ -31,7 +32,7 @@ cspice_root = os.getenv('CSPICEPATH', os.path.join(ROOT_DIR, 'cspice'))
 #    print('ERROR: spice not found') #XXX search lib in default locations?
 #    sys.exit(1)
 cspice_include = os.path.join(cspice_root, 'include')
-cspice_lib = os.path.join(cspice_root, 'lib', 'cspice.a') #XXX same under windows?
+cspice_lib = os.path.join(cspice_root, 'lib', 'cspice.lib' if platform.system() == 'Windows' else 'cspice.a')
 
 src_files = glob.glob(os.path.join(ROOT_DIR, 'cwrapper', '*.c'))
 cwrapper = Extension('.'.join([PROJECT_NAME, 'libspice']), src_files,

--- a/utils/data-naif.json
+++ b/utils/data-naif.json
@@ -15,7 +15,7 @@
                             ]
                         },
                         {
-                            "name": "sattelites",
+                            "name": "satellites",
                             "files": [
                                 "mar097.bsp"
                             ]


### PR DESCRIPTION
I did some adjustments to `getcspice.py` and `setup.py` for them to run on Windows systems (tested on Windows 10 64bit with Python 3.5.1).
The `python setup.py cspice` command is now able to download and extract the correct zip file for Windows.
`python setup.py build_ext --inplace` now uses the correct `cspice.lib` file, but compiling doesn't work correctly for me yet and I don't know how to fix that (see #5 ).
